### PR TITLE
remove robot-type restriction and add joints prefix

### DIFF
--- a/abb_bringup/config/abb_controllers.yaml
+++ b/abb_bringup/config/abb_controllers.yaml
@@ -14,12 +14,12 @@ controller_manager:
 joint_trajectory_controller:
   ros__parameters:
     joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+      - abb_irb4600_joint_1
+      - abb_irb4600_joint_2
+      - abb_irb4600_joint_3
+      - abb_irb4600_joint_4
+      - abb_irb4600_joint_5
+      - abb_irb4600_joint_6
     command_interfaces:
       - position
       - velocity
@@ -36,10 +36,10 @@ joint_trajectory_controller:
 forward_command_controller_position:
   ros__parameters:
     joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+      - abb_irb4600_joint_1
+      - abb_irb4600_joint_2
+      - abb_irb4600_joint_3
+      - abb_irb4600_joint_4
+      - abb_irb4600_joint_5
+      - abb_irb4600_joint_6
     interface_name: position

--- a/abb_bringup/launch/abb_moveit.launch.py
+++ b/abb_bringup/launch/abb_moveit.launch.py
@@ -157,28 +157,24 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "robot_xacro_file",
             description="Xacro describing the robot.",
-            choices=["irb1200_5_90.xacro"],
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "support_package",
             description="Name of the support package",
-            choices=["abb_irb1200_support"],
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "moveit_config_package",
             description="Name of the support package",
-            choices=["abb_irb1200_5_90_moveit_config"],
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "moveit_config_file",
             description="Name of the SRDF file",
-            choices=["abb_irb1200_5_90.srdf.xacro"],
         )
     )
 


### PR DESCRIPTION
when launching the `abb_moveit.launch.py` the only supported robot is the `irb1200_5_90`, remapping to another robot was not allowed due to the restrictions set in the launch file by the parameter `choices` in `DeclareLaunchArgument`.
The joints names in the controller's yaml file were missing the prefix we use for the robot so I renamed them accordingly

Removed the parameter to allow setting the robot type and files without limitations